### PR TITLE
Serialnumber to HEX

### DIFF
--- a/lib/dreamscreen/client.js
+++ b/lib/dreamscreen/client.js
@@ -286,9 +286,10 @@ Client.prototype.handleReceivedPacket = function (received, rinfo) {
     } else {    //update state of light
 
         if (commandReceived == 0x0103) {
-            let serialNumber = utils.subBufferString(0, 4, payload)
+            let serialNumber = utils.subBufferString(0, 4, payload);
+            serialNumber = Buffer.from(serialNumber, 'utf8').toString('hex');
             if (this.debug) {
-                console.log(`0x0103 serial number received`);   //${serialNumber}   //not human readable
+                console.log(`0x0103 serial number received`); 
             }
 
             light.serialNumber = serialNumber;


### PR DESCRIPTION
Changed serialnumber from unreadable to HEX, This way it's usable as an reference ID. Tested this change on the NEEO driver.